### PR TITLE
[codex] Add agent instruction dotfiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@
 vim/autoload/
 vim/plugged/
 config/tmux/plugins/
+
+# local private instruction overrides
+*.local.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# Global Codex Instructions
+
+These are the default instructions for Codex when working from this dotfiles setup.
+Use the focused companion files when the task touches one of those systems:
+
+- [GITHUB.md](GITHUB.md) for GitHub CLI, authentication, PRs, issues, and repository work.
+- [LINEAR.md](LINEAR.md) for Linear issues, projects, comments, and workflow changes.
+
+Private machine-specific details may live in ignored `*.local.md` files next to
+these public instructions. If such a file exists for the relevant area, read it
+as a local override and never commit its contents.
+
+## Git Branch Isolation
+
+For coding work in a git repository, start each new Codex thread on its own branch
+or isolated worktree before editing. When the work has a Linear issue, include
+the issue ID in the branch name, for example `codex/ABC-123-short-task`.
+Otherwise, prefer a branch name like `codex/short-task`.
+
+Before switching branches or creating a worktree, inspect git status. If there are
+uncommitted changes that may belong to the user or another thread, do not
+overwrite or move them; either create a separate worktree from the current HEAD or
+ask the user how to proceed.
+
+When creating a worktree manually, prefer placing it inside the repository
+workspace, for example `.worktrees/codex-short-task`, instead of `/tmp` or
+`/private/tmp`. This keeps file edits inside the Codex workspace permissions and
+avoids repeated approval prompts for normal code changes.
+
+If an in-repo worktree path is ignored by git, use it for isolation. If it is not
+ignored, add only the minimal ignore rule needed for `.worktrees/` before creating
+the worktree.
+
+When the Codex app already provides an isolated worktree for the thread, use that
+isolation and keep commits/branches scoped to the task.

--- a/GITHUB.md
+++ b/GITHUB.md
@@ -1,0 +1,51 @@
+# GitHub Instructions
+
+## Token Access
+
+For GitHub access, use the configured local GitHub CLI credentials or a local
+helper that injects `GH_TOKEN` without printing it.
+
+Machine-specific credential details may live in an ignored `GITHUB.local.md`
+file. Read it when present, but never commit or quote its contents.
+
+Prefer the `gh-codex` helper for GitHub CLI work when it is available, so use
+commands like:
+
+```sh
+gh-codex repo view OWNER/REPO
+gh-codex pr view 123 --repo OWNER/REPO
+```
+
+Never hard-code, print, commit, or document personal access tokens, Keychain item
+names, credential helper internals, or private credential commands. Avoid
+`gh auth status` unless debugging because it may show a masked token prefix.
+
+## PR Standard
+
+Every PR should explain:
+
+- What changed
+- Why
+- Linear issue identifier or link, when applicable
+- Acceptance criteria checked, when applicable
+- Screenshots, Loom, or preview URL when relevant
+- Risk
+- How to test
+- What was intentionally not done
+- Agent involvement
+- Follow-up issues created, if any
+
+Use the narrowest useful verification command for the task. If a broad check is
+already known to have unrelated failures, say that plainly in the PR and include
+the more targeted checks that passed.
+
+## PR Review Standard
+
+When reviewing a PR, return feedback in three groups:
+
+1. Must fix before merge
+2. Should fix soon
+3. Safe to merge
+
+Use the first group for blocking findings. Use `Safe to merge` when there are no
+blocking findings, and include any residual risk or test gaps there.

--- a/LINEAR.md
+++ b/LINEAR.md
@@ -1,0 +1,75 @@
+# Linear Instructions
+
+Use Linear when the task is about Linear issues, projects, initiatives, comments,
+customer needs, team workflows, or status updates.
+
+Project work should have a Linear issue. If a project task does not have one, ask
+to create a Linear issue before starting implementation.
+
+Prefer the Linear app tools when they are available. Use structured Linear
+operations for reading, creating, and updating Linear entities instead of relying
+on browser automation or ad hoc text copying.
+
+## Default Workflow
+
+Before editing:
+
+- Read the Linear issue, linked spec, and relevant existing files.
+- Identify the acceptance criteria and non-goals.
+- If the issue lacks acceptance criteria or the scope is ambiguous, ask for
+  clarification before editing.
+- Check current implementation patterns before adding new ones.
+- Inspect current git status so unrelated work is not disturbed.
+
+While editing:
+
+- Implement only the stated acceptance criteria.
+- Do not change unrelated files.
+- Do not refactor opportunistically.
+- Preserve existing behavior unless the issue explicitly changes it.
+- Follow existing code style, architecture, naming, and UI conventions.
+- Add or update tests when the change affects logic, data flow, permissions,
+  integrations, or user-visible behavior.
+
+Before opening a PR:
+
+- Run the relevant checks for the files touched.
+- Use the narrowest useful verification command for the task.
+- If a broad check is already known to have unrelated failures, say that plainly
+  in the PR and include the more targeted checks that passed.
+- Review the diff for unrelated changes.
+
+## Linear Updates
+
+When changing Linear data, preserve existing issue context and make focused
+updates:
+
+- Fetch the relevant issue, project, initiative, or document before editing it.
+- Prefer updating existing entities over creating duplicates.
+- Use issue identifiers, project names, and team names exactly as Linear reports
+  them.
+- Add comments for discussion or progress notes; edit issue fields only when the
+  user asked for a field-level workflow change.
+- Keep descriptions and comments in clear Markdown.
+- After implementation, post a concise progress comment or move issue status
+  only when the user asked for that Linear update.
+
+## PR Standard
+
+For PR creation, description, review formatting, GitHub CLI, and authentication
+details, follow [GITHUB.md](GITHUB.md).
+
+Create follow-up Linear issues only when the user asks or when deferred work is
+required to preserve the intended scope.
+
+## PR Review Standard
+
+Review against the linked Linear issue only. Look for acceptance criteria gaps,
+bugs, broken data flow, unnecessary scope expansion, security issues, bad
+abstractions, missing loading or error states, and code that will be hard for
+future agents to modify.
+
+Do not suggest unrelated improvements unless they are severe.
+
+Use `Safe to merge` only when there are no blocking findings, and include any
+residual risk or test gaps there.

--- a/bin/make.sh
+++ b/bin/make.sh
@@ -84,11 +84,26 @@ link_dotfile() {
   fi
 }
 
+link_optional_dotfile() {
+  local source="$1"
+  local dest="$2"
+
+  if [ -e "$source" ]; then
+    link_dotfile "$source" "$dest"
+  fi
+}
+
 link_dotfile "zshrc" ".zshrc"
 link_dotfile "vimrc" ".vimrc"
 link_dotfile "Brewfile" ".Brewfile"
 link_dotfile "gitconfig" ".gitconfig"
 link_dotfile "gitignore" ".gitignore"
+link_dotfile "AGENTS.md" ".codex/AGENTS.md"
+link_dotfile "GITHUB.md" ".codex/GITHUB.md"
+link_dotfile "LINEAR.md" ".codex/LINEAR.md"
+link_optional_dotfile "AGENTS.local.md" ".codex/AGENTS.local.md"
+link_optional_dotfile "GITHUB.local.md" ".codex/GITHUB.local.md"
+link_optional_dotfile "LINEAR.local.md" ".codex/LINEAR.local.md"
 link_dotfile "config/alacritty" ".config/alacritty"
 link_dotfile "config/ghostty" ".config/ghostty"
 link_dotfile "config/tmux" ".config/tmux"


### PR DESCRIPTION
## What changed
- Added public Codex instruction files: AGENTS.md, GITHUB.md, and LINEAR.md.
- Updated the dotfiles installer to link the instruction files into ~/.codex.
- Added ignored *.local.md support for private machine-specific overrides.

## Why
To keep reusable Codex workflow guidance in dotfiles while avoiding committing private credential details.

## Linear issue
Not applicable.

## Acceptance criteria checked
- Main AGENTS.md references focused GitHub and Linear instruction files.
- GitHub-specific PR and credential guidance lives in GITHUB.md.
- Linear workflow and review guidance lives in LINEAR.md.
- Private local override files are ignored and optionally linked when present.

## Screenshots, Loom, or preview URL
Not applicable.

## Risk
Low. Changes are documentation and symlink setup only.

## How to test
- bash -n bin/make.sh
- env HOME=/private/tmp/dotfiles-pr-verify bash bin/make.sh
- rg -n "codex-github-token|security find|fine-grained|Keychain with account|GH_TOKEN=|PAT is stored" .gitignore AGENTS.md GITHUB.md LINEAR.md bin/make.sh

## What was intentionally not done
- Did not commit private local credential notes.
- Did not add a project-specific Linear issue because this is dotfiles setup work.

## Agent involvement
Codex created the files, updated the installer, verified public files for sensitive credential details, committed, and opened this draft PR.

## Follow-up issues created
None.