### PR TITLE
[codex] Add mandatory pre-edit checklist

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,27 @@ Private machine-specific details may live in ignored `*.local.md` files next to
 these public instructions. If such a file exists for the relevant area, read it
 as a local override and never commit its contents.
 
+## Mandatory Pre-Edit Checklist
+
+Before editing files for any coding or project task:
+
+1. Read this file and any relevant focused companion files:
+   - [WEB.md](WEB.md) for frontend, browser, HTML, CSS, accessibility,
+     performance, or modern web work.
+   - [LINEAR.md](LINEAR.md) for project work, issue workflow, scope, or status
+     changes.
+   - [GITHUB.md](GITHUB.md) for repository, PR, issue, or CI work.
+2. Check for matching ignored `*.local.md` files next to those companion files
+   and apply them as local overrides.
+3. Run `git status --short --branch`.
+4. If the task is project work and no Linear issue is provided, ask whether to
+   create one before implementation.
+5. Create or switch to the task branch or worktree before editing.
+6. State the issue, branch, docs-read, and verification plan briefly before
+   making changes.
+7. Do not change unrelated files or package metadata unless the user explicitly
+   approves that expanded scope.
+
 ## Git Branch Isolation
 
 For coding work in a git repository, start each new Codex thread on its own branch

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,9 +28,12 @@ Before editing files for any coding or project task:
 4. If the task is project work and no Linear issue is provided, ask whether to
    create one before implementation.
 5. Create or switch to the task branch or worktree before editing.
-6. State the issue, branch, docs-read, and verification plan briefly before
+6. When using a separate worktree, symlink required ignored env files such as
+   `.env`, `.env.local`, and `.dev.vars` from the main checkout when they exist
+   so the environment works without copying secret contents.
+7. State the issue, branch, docs-read, and verification plan briefly before
    making changes.
-7. Do not change unrelated files or package metadata unless the user explicitly
+8. Do not change unrelated files or package metadata unless the user explicitly
    approves that expanded scope.
 
 ## Git Branch Isolation


### PR DESCRIPTION
## What changed

- Added a Mandatory Pre-Edit Checklist to `AGENTS.md`.
- Made the expected docs-read, local override, git status, branch/worktree, scope, and verification steps explicit before coding/project edits.

## Why

A recent new chat missed the global `AGENTS.md` guidance. This makes the pre-edit requirements more prominent and operational.

## Linear issue

None provided; this is a direct dotfiles instruction update.

## Acceptance criteria checked

- Confirmed no matching ignored `*.local.md` override files are present.
- Confirmed the diff only changes `AGENTS.md`.
- Read back the updated checklist.

## Risk

Low. Markdown-only instruction update.

## How to test

- Manual readback of `AGENTS.md`.
- `git diff -- AGENTS.md` before commit.

## Intentionally not done

- Did not change companion instruction files.
- Did not alter package metadata or unrelated files.

## Agent involvement

Implemented, verified, committed, pushed, and opened by Codex.