### PR TITLE
[codex] Clarify web guidance skill install location

### DIFF
--- a/WEB.md
+++ b/WEB.md
@@ -14,8 +14,11 @@ installed:
 If it is not installed, install it with the Chrome team's recommended installer:
 
 ```sh
-npx -y modern-web-guidance@latest install
+(cd "$HOME" && npx -y modern-web-guidance@latest install)
 ```
+
+Run the installer from `$HOME` so it installs to the global user-level skill
+location instead of creating a project-local `./.agents` directory.
 
 After installation in the current session, read and follow the installed
 `SKILL.md` directly if the skill is not automatically loaded yet. New Codex


### PR DESCRIPTION
## Summary
- Update WEB.md to run the Modern Web Guidance installer from $HOME.
- Document that this avoids creating project-local ./.agents directories.

## Validation
- Confirmed ~/.codex/WEB.md symlinks to the dotfiles WEB.md.
- Branch is clean and pushed.